### PR TITLE
Added logic for custom clicks and updated example

### DIFF
--- a/Adhese SDK Sample/Adhese SDK Sample/UI/MainViewController.m
+++ b/Adhese SDK Sample/Adhese SDK Sample/UI/MainViewController.m
@@ -62,6 +62,9 @@ AdView *halfPageAdview;
     AdheseOptions *options = [[AdheseOptions alloc] initWithLocation:@"_demo_ster_a_"];
     options.cookieMode = kAll;
     options.slots = @[@"billboard", @"halfpage"];
+    
+    self.billboardAdview.shouldOpenAd = NO; // This line is neccessary to handle custom click logic, see adClicked
+
   
     [Adhese loadAds:options withCompletionHandler:^(NSArray<Ad *> * _Nonnull ads, AdheseError * _Nullable error) {
         
@@ -136,6 +139,11 @@ AdView *halfPageAdview;
     }
     
     [events addObject:[NSString stringWithFormat:@"%@ did load.", view.ad.slotName]];
+}
+
+// Example for custom click handling
+- (void)adClicked:(AdView *)adView withURL:(NSURL *)url {
+    NSLog(@"Ad clicked, navigating to: %@", url.absoluteString);
 }
 
 -(void)viewImpressionWasNotified:(id)adView withError:(AdheseError * _Nullable)error {

--- a/Adhese SDK Sample/Adhese SDK Sample/UI/MainViewController.m
+++ b/Adhese SDK Sample/Adhese SDK Sample/UI/MainViewController.m
@@ -65,7 +65,6 @@ AdView *halfPageAdview;
     
     self.billboardAdview.shouldOpenAd = NO; // This line is neccessary to handle custom click logic, see adClicked
 
-  
     [Adhese loadAds:options withCompletionHandler:^(NSArray<Ad *> * _Nonnull ads, AdheseError * _Nullable error) {
         
         if (error) {
@@ -141,7 +140,7 @@ AdView *halfPageAdview;
     [events addObject:[NSString stringWithFormat:@"%@ did load.", view.ad.slotName]];
 }
 
-// Example for custom click handling
+// Example for custom click handling, see "Extra" in the README.md
 - (void)adClicked:(AdView *)adView withURL:(NSURL *)url {
     NSLog(@"Ad clicked, navigating to: %@", url.absoluteString);
 }

--- a/Adhese SDK.xcodeproj/project.pbxproj
+++ b/Adhese SDK.xcodeproj/project.pbxproj
@@ -560,7 +560,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.endare.adhese.sdk;
 				PRODUCT_NAME = AdheseSDK;
 				SKIP_INSTALL = YES;
@@ -587,7 +587,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.endare.adhese.sdk;
 				PRODUCT_NAME = AdheseSDK;
 				SKIP_INSTALL = YES;

--- a/Adhese SDK/UI/AdView.h
+++ b/Adhese SDK/UI/AdView.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @optional
 - (void)adClicked:(id)adView withError:(AdheseError * _Nullable)error;
+- (void)adClicked:(id)adView withURL:(NSURL *)url;
 
 @end
 

--- a/Adhese.podspec
+++ b/Adhese.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "Adhese"
-  spec.version      = "1.0.7"
+  spec.version      = "1.0.8"
   spec.summary      = "The official Adhese SDK for iOS."
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
I changed the following:

- Fix issue where the app would open an external URL within the adview itself and not redirecting to an external browser because of IOS 10 compatibility.
- Added logic for handling in-app navigation. 
- Updated the the SDK example to contain an example of custom click logic